### PR TITLE
feat: use stream to select new items

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Then import and use the [FortuneWheel](https://pub.dev/documentation/flutter_for
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter_fortune_wheel/flutter_fortune_wheel.dart';
-
+StreamController<int> controller = StreamController<int>();
 FortuneWheel(
-  selected: 0,
+  selected: controller.stream,
   items: [
     FortuneItem(child: Text('Han Solo')),
     FortuneItem(child: Text('Yoda')),
@@ -51,8 +51,9 @@ the fortune bar, which is smaller in the vertical direction, is provided as an a
 import 'package:flutter/material.dart';
 import 'package:flutter_fortune_wheel/flutter_fortune_wheel.dart';
 
+StreamController<int> controller = StreamController<int>();
 FortuneBar(
-  selected: 0,
+  selected: controller.stream,
   items: [
     FortuneItem(child: Text('Han Solo')),
     FortuneItem(child: Text('Yoda')),
@@ -77,7 +78,7 @@ The callback passed to `onFling` is called when the pan physics detects a fling 
 you the opportunity to select a new random item.
 
 ```dart
-int selected = 0;
+StreamController<int> controller = StreamController<int>();
 FortuneWheel(
   // changing the return animation when the user stops dragging
   physics: CircularPanPhysics(
@@ -85,9 +86,9 @@ FortuneWheel(
     curve: Curves.decelerate,
   ),
   onFling: () {
-    selected = 1;
+    controller.add(1);
   }
-  selected: selected,
+  selected: controller.stream,
   items: [
     FortuneItem(child: Text('Han Solo')),
     FortuneItem(child: Text('Yoda')),
@@ -107,7 +108,7 @@ As with drag behavior, you can pass custom implementations to the `styleStrategy
 ```dart
 // styling FortuneItems individually
 FortuneWheel(
-  selected: 0,
+  selected: Stream.value(0),
   items: [
     FortuneItem(
       child: Text('A'),
@@ -125,7 +126,7 @@ FortuneWheel(
 FortuneBar(
   // using alternating item styles on a fortune bar
   styleStrategy: AlternatingStyleStrategy(),
-  selected: 0,
+  selected: Stream.value(0),
   items: [
     FortuneItem(child: Text('Han Solo')),
     FortuneItem(child: Text('Yoda')),

--- a/demo/lib/common/roll_button.dart
+++ b/demo/lib/common/roll_button.dart
@@ -1,29 +1,17 @@
 part of 'common.dart';
 
-int roll(int itemCount, {int lastValue}) {
-  if (lastValue == null) {
-    return Random().nextInt(itemCount);
-  } else {
-    int val = lastValue;
-    while (val == lastValue) {
-      val = Random().nextInt(itemCount);
-    }
-    return val;
-  }
+int roll(int itemCount) {
+  return Random().nextInt(itemCount);
 }
 
 typedef IntCallback = void Function(int);
 
 class RollButton extends StatelessWidget {
-  final int lastValue;
   final VoidCallback onPressed;
-  final int itemCount;
 
   const RollButton({
     Key key,
     this.onPressed,
-    this.itemCount,
-    this.lastValue,
   }) : super(key: key);
 
   @override
@@ -54,11 +42,7 @@ class RollButtonWithPreview extends StatelessWidget {
       crossAxisAlignment: WrapCrossAlignment.center,
       direction: Axis.vertical,
       children: [
-        RollButton(
-          itemCount: items.length,
-          onPressed: onPressed,
-          lastValue: selected,
-        ),
+        RollButton(onPressed: onPressed),
         Text('Rolled Value: ${items[selected]}'),
       ],
     );

--- a/demo/lib/pages/bar.dart
+++ b/demo/lib/pages/bar.dart
@@ -6,13 +6,13 @@ import 'package:fortune_wheel_demo/common/common.dart';
 class FortuneBarPage extends HookWidget {
   @override
   Widget build(BuildContext context) {
-    final selected = useState(0);
+    final selected = useStreamController<int>();
+    final selectedIndex = useStream(selected.stream, initialData: 0).data ?? 0;
     final isAnimating = useState(false);
 
     void handleRoll() {
-      selected.value = roll(
-        fortuneValues.length,
-        lastValue: selected.value,
+      selected.add(
+        roll(fortuneValues.length),
       );
     }
 
@@ -20,7 +20,7 @@ class FortuneBarPage extends HookWidget {
       children: [
         SizedBox(height: 8),
         RollButtonWithPreview(
-          selected: selected.value,
+          selected: selectedIndex,
           items: fortuneValues,
           onPressed: isAnimating.value ? null : handleRoll,
         ),
@@ -28,7 +28,7 @@ class FortuneBarPage extends HookWidget {
         Expanded(
           child: Center(
             child: FortuneBar(
-              selected: selected.value,
+              selected: selected.stream,
               items: [
                 for (var it in fortuneValues) FortuneItem(child: Text(it))
               ],

--- a/demo/lib/pages/wheel.dart
+++ b/demo/lib/pages/wheel.dart
@@ -7,7 +7,8 @@ class FortuneWheelPage extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final alignment = useState(Alignment.topCenter);
-    final selected = useState(0);
+    final selected = useStreamController<int>();
+    final selectedIndex = useStream(selected.stream, initialData: 0).data ?? 0;
     final isAnimating = useState(false);
 
     final alignmentSelector = AlignmentSelector(
@@ -16,9 +17,8 @@ class FortuneWheelPage extends HookWidget {
     );
 
     void handleRoll() {
-      selected.value = roll(
-        fortuneValues.length,
-        lastValue: selected.value,
+      selected.add(
+        roll(fortuneValues.length),
       );
     }
 
@@ -29,14 +29,14 @@ class FortuneWheelPage extends HookWidget {
           alignmentSelector,
           SizedBox(height: 8),
           RollButtonWithPreview(
-            selected: selected.value,
+            selected: selectedIndex,
             items: fortuneValues,
             onPressed: isAnimating.value ? null : handleRoll,
           ),
           SizedBox(height: 8),
           Expanded(
             child: FortuneWheel(
-              selected: selected.value,
+              selected: selected.stream,
               onAnimationStart: () => isAnimating.value = true,
               onAnimationEnd: () => isAnimating.value = false,
               onFling: handleRoll,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -23,7 +24,13 @@ class ExamplePage extends StatefulWidget {
 }
 
 class _ExamplePageState extends State<ExamplePage> {
-  int selected = 0;
+  StreamController<int> selected = StreamController<int>();
+
+  @override
+  void dispose() {
+    selected.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,14 +52,16 @@ class _ExamplePageState extends State<ExamplePage> {
       body: GestureDetector(
         onTap: () {
           setState(() {
-            selected = Random().nextInt(items.length);
+            selected.add(
+              Random().nextInt(items.length),
+            );
           });
         },
         child: Column(
           children: [
             Expanded(
               child: FortuneWheel(
-                selected: selected,
+                selected: selected.stream,
                 items: [
                   for (var it in items) FortuneItem(child: Text(it)),
                 ],

--- a/lib/src/bar/fortune_bar.dart
+++ b/lib/src/bar/fortune_bar.dart
@@ -30,7 +30,7 @@ class FortuneBar extends HookWidget implements FortuneWidget {
   final List<FortuneItem> items;
 
   /// {@macro flutter_fortune_wheel.FortuneWidget.selected}
-  final int selected;
+  final Stream<int> selected;
 
   /// {@macro flutter_fortune_wheel.FortuneWidget.rotationCount}
   final int rotationCount;
@@ -120,9 +120,15 @@ class FortuneBar extends HookWidget implements FortuneWidget {
       return null;
     }, []);
 
-    useValueChanged(selected, (int _, Future<void>? __) async {
-      await animate();
-    });
+    final selectedIndex = useState<int>(0);
+
+    useEffect(() {
+      final subscription = selected.listen((event) {
+        selectedIndex.value = event;
+        animate();
+      });
+      return subscription.cancel;
+    }, []);
 
     final theme = Theme.of(context);
 
@@ -145,7 +151,7 @@ class FortuneBar extends HookWidget implements FortuneWidget {
                     animation: animation,
                     builder: (context, _) {
                       final itemPosition =
-                          (items.length * rotationCount + selected);
+                          (items.length * rotationCount + selectedIndex.value);
                       final panFactor = 2 / size.width;
                       final panOffset = -panState.distance * panFactor;
                       final position =

--- a/lib/src/core/fortune_widget.dart
+++ b/lib/src/core/fortune_widget.dart
@@ -20,10 +20,10 @@ abstract class FortuneWidget implements Widget {
   List<FortuneItem> get items;
 
   /// {@template flutter_fortune_wheel.FortuneWidget.selected}
-  /// The currently selected index within [items].
+  /// A stream notifying this widget that a new value within [items] was selected.
   /// Used by [FortuneWidget]s to align [indicators] on the selected item.
   /// {@endtemplate}
-  int get selected;
+  Stream<int> get selected;
 
   /// {@template flutter_fortune_wheel.FortuneWidget.rotationCount}
   /// The number of times a [FortuneWidget] rotates around all

--- a/test/fortune_bar_test.dart
+++ b/test/fortune_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_fortune_wheel/flutter_fortune_wheel.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -24,7 +26,7 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: false,
-              selected: Stream.value(0),
+              selected: Stream.empty(),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -56,7 +58,7 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: true,
-              selected: Stream.value(0),
+              selected: Stream.empty(),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -86,12 +88,13 @@ void main() {
             endLog.add(true);
           }
 
+          final controller = StreamController<int>();
+
           await pumpFortuneWidget(
             tester,
             FortuneBar(
               animateFirst: false,
-              // TODO: refactor this to use a single stream controller for updates
-              selected: Stream.value(0),
+              selected: controller.stream,
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
@@ -103,23 +106,15 @@ void main() {
           expect(startLog, isEmpty);
           expect(endLog, isEmpty);
 
-          await pumpFortuneWidget(
-            tester,
-            FortuneBar(
-              animateFirst: false,
-              selected: Stream.value(1),
-              items: testItems,
-              onAnimationStart: onStart,
-              onAnimationEnd: onEnd,
-            ),
-          );
-
+          controller.add(1);
           await tester.pumpAndSettle();
 
           expect(startLog, hasLength(1));
           expect(startLog, contains(true));
           expect(endLog, hasLength(1));
           expect(endLog, contains(true));
+
+          controller.close();
         },
       );
     });

--- a/test/fortune_bar_test.dart
+++ b/test/fortune_bar_test.dart
@@ -24,7 +24,7 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: false,
-              selected: 0,
+              selected: Stream.value(0),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -56,7 +56,7 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: true,
-              selected: 0,
+              selected: Stream.value(0),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -90,7 +90,8 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: false,
-              selected: 0,
+              // TODO: refactor this to use a single stream controller for updates
+              selected: Stream.value(0),
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
@@ -106,7 +107,7 @@ void main() {
             tester,
             FortuneBar(
               animateFirst: false,
-              selected: 1,
+              selected: Stream.value(1),
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,

--- a/test/fortune_wheel_test.dart
+++ b/test/fortune_wheel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_fortune_wheel/flutter_fortune_wheel.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -24,7 +26,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: false,
-              selected: Stream.value(0),
+              selected: Stream.empty(),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -56,7 +58,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: true,
-              selected: Stream.value(0),
+              selected: Stream.empty(),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -86,11 +88,13 @@ void main() {
             endLog.add(true);
           }
 
+          final controller = StreamController<int>();
+
           await pumpFortuneWidget(
             tester,
             FortuneWheel(
               animateFirst: false,
-              selected: Stream.value(0),
+              selected: controller.stream,
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
@@ -102,23 +106,15 @@ void main() {
           expect(startLog, isEmpty);
           expect(endLog, isEmpty);
 
-          await pumpFortuneWidget(
-            tester,
-            FortuneWheel(
-              animateFirst: false,
-              selected: Stream.value(1),
-              items: testItems,
-              onAnimationStart: onStart,
-              onAnimationEnd: onEnd,
-            ),
-          );
-
+          controller.add(1);
           await tester.pumpAndSettle();
 
           expect(startLog, hasLength(1));
           expect(startLog, contains(true));
           expect(endLog, hasLength(1));
           expect(endLog, contains(true));
+
+          controller.close();
         },
       );
     });

--- a/test/fortune_wheel_test.dart
+++ b/test/fortune_wheel_test.dart
@@ -24,7 +24,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: false,
-              selected: 0,
+              selected: Stream.value(0),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -56,7 +56,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: true,
-              selected: 0,
+              selected: Stream.value(0),
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
               items: testItems,
@@ -90,7 +90,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: false,
-              selected: 0,
+              selected: Stream.value(0),
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,
@@ -106,7 +106,7 @@ void main() {
             tester,
             FortuneWheel(
               animateFirst: false,
-              selected: 1,
+              selected: Stream.value(1),
               items: testItems,
               onAnimationStart: onStart,
               onAnimationEnd: onEnd,


### PR DESCRIPTION
Currently, a `FortuneWidget`'s animation will not be triggered, when the same value is selected multiple times in a row. This is due to the implementation checking for inequality of a new value.

With this change, `FortuneWidget`s will be passed a `Stream<int>` instead of `int` for the _selected_ property, which triggers the animation whenever the stream sends a new value.

Since this feature changes the public API, it will be shipped with the next major version update.