### PR TITLE
Fix NaN and infinite value handling in FortuneWheel

### DIFF
--- a/lib/src/wheel/fortune_wheel.dart
+++ b/lib/src/wheel/fortune_wheel.dart
@@ -295,6 +295,14 @@ class FortuneWheel extends HookWidget implements FortuneWidget {
   ) {
     final step = 360 / itemsNumber;
     final angleDegrees = (angle * 180 / _math.pi).abs() + step / 2;
+    if (step.isNaN ||
+        angleDegrees.isNaN ||
+        lastVibratedAngle.value.isNaN ||
+        lastVibratedAngle.value.isInfinite ||
+        angleDegrees.isInfinite ||
+        step == 0) {
+      return null;
+    }
     if (lastVibratedAngle.value ~/ step == angleDegrees ~/ step) {
       return null;
     }


### PR DESCRIPTION
We got this error and I fixed. 
Unsupported operation: Infinity or NaN toInt. Error thrown building Widget.
double.~/
double.~/ (dart:core)
FortuneWheel._vibrateIfBorderCrossed (fortune_wheel.dart:298)
FortuneWheel.build.<fn>.<fn>.<fn> (fortune_wheel.dart:249)